### PR TITLE
Add UK BitBar Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@
 |:------|:-------------|:-------|:---------|
 | [Costa Rica Tracker](https://github.com/bryandms/covid-19costaricatracker) | MacOS MenuBar Tracker for Costa Rica (configurable for others). | [bryandms](https://github.com/bryandms) | English
 | [Alert COVID-19](https://github.com/renanbastos93/alertcovid19) | Alert COVID-19 is a small multiplatform tool written in Golang to help keep you informed about the current situation of COVID-19 in your region, while you stay safe at home. | [Renan Bastos](https://github.com/renanbastos93) | English
+| [UK tracker](https://github.com/benjamin-sommer/covid-19-uk-tracker) | MacOS MenuBar Tracker for UK and World | [Ben Sommer](https://github.com/benjamin-sommer) | English
+
+
 
 ## Bots
 


### PR DESCRIPTION
Add UK MacOS MenuBar tracker using [NovelCOVID API](https://github.com/NovelCOVID/API)