### PR TITLE
Add COVID-19 Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 | [COVID-19 Tracker](http://tcovid19.herokuapp.com/) | Dashboard with data visualisations for both India & rest of the world. | [thecoducer](https://github.com/thecoducer) | English
 | [Corona Live](https://coronaisrael.live/) | Get live statistics on the spread of Coronavirus in Israel and in other countries around the world. (English version coming soon) | [meirroth](https://github.com/meirroth) | Hebrew
 | [Tracking COVID-19](https://tracking-covid-19.herokuapp.com) | Dashboard to track the spread of COVID-19 outbreak. | [simongjetaj](https://github.com/simongjetaj) | English
-| [COVID-19 Dashboard](https://josiahyeow.github.io/covid-19-dashboard/) | Simple dashboard which shows the curve of country and (Australian) state data. | [josiahyeow](https://github.com/josiahyeow) | English
+| [COVID-19 Dashboard](https://josiahyeow.github.io/covid-19-dashboard/) | Simple dashboard which shows the numbers and curve of country and (Australian) state data. | [josiahyeow](https://github.com/josiahyeow) | English
 
 ## Mobile Applications
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | [COVID-19 Tracker](http://tcovid19.herokuapp.com/) | Dashboard with data visualisations for both India & rest of the world. | [thecoducer](https://github.com/thecoducer) | English
 | [Corona Live](https://coronaisrael.live/) | Get live statistics on the spread of Coronavirus in Israel and in other countries around the world. (English version coming soon) | [meirroth](https://github.com/meirroth) | Hebrew
 | [Tracking COVID-19](https://tracking-covid-19.herokuapp.com) | Dashboard to track the spread of COVID-19 outbreak. | [simongjetaj](https://github.com/simongjetaj) | English
+| [COVID-19 Dashboard](https://josiahyeow.github.io/covid-19-dashboard/) | Simple dashboard which shows the curve of country and (Australian) state data. | [josiahyeow](https://github.com/josiahyeow) | English
 
 ## Mobile Applications
 


### PR DESCRIPTION
I would like to add my dashboard to your collection as it wouldn't have been possible without the NovelCOVID dataset. It's a simple dashboard which displays the numbers and curve for confirmed, active, recovered and deaths as well as the difference each day. It currently supports all the countries provided by the dataset as well as Australian states. I may add support for states in other countries in the future.

Notable features:
- Ability to change what metric the graphs show
- View multiple states on one screen
- Responsive design
- Light and dark mode
- Support as a PWA

https://josiahyeow.github.io/covid-19-dashboard/

Thanks!